### PR TITLE
Fix incorrect `self` value expectation

### DIFF
--- a/match.go
+++ b/match.go
@@ -221,10 +221,10 @@ func (m *Match) Commit(round Round) {
 		self := score[1]
 
 		m.Players[i].AddKills(kills);
-		if self == 1 {
+		if self == -1 {
 			m.Players[i].AddSelf();
 		}
-		if self == 1 || kills == 3 || round.Shots[i] {
+		if self == -1 || kills == 3 || round.Shots[i] {
 			m.Players[i].AddShot()
 		}
 	}

--- a/match_test.go
+++ b/match_test.go
@@ -182,7 +182,7 @@ func TestCommitSweepAndSuicidePlayer3(t *testing.T) {
 		Kills: [][]int{
 			[]int{0, 0},
 			[]int{0, 0},
-			[]int{3, 1},
+			[]int{3, -1},
 			[]int{0, 0},
 		},
 		Shots: []bool{
@@ -213,7 +213,7 @@ func TestCommitSuicidePlayer4(t *testing.T) {
 			[]int{0, 0},
 			[]int{0, 0},
 			[]int{0, 0},
-			[]int{0, 1},
+			[]int{0, -1},
 		},
 		Shots: []bool{
 			false,


### PR DESCRIPTION
PR #108 introduced a bug where the value for the `self` field in the `Commit` action was expected to be positive. This fixes that and modifies the tests to cover this case.