### PR TITLE
[WIP] Remove kind pluralization logic

### DIFF
--- a/js/src/components/Match.vue
+++ b/js/src/components/Match.vue
@@ -136,12 +136,6 @@ export default {
       })
     },
     setData: function (tournament, kind, match) {
-      if (kind === 'tryout') {
-        kind = 'tryouts'
-      } else if (kind === 'semi') {
-        kind = 'semis'
-      }
-
       if (kind === 'final') {
         this.$set('match', Match.fromObject(tournament[kind]))
       } else {

--- a/js/src/components/NextScreen.vue
+++ b/js/src/components/NextScreen.vue
@@ -60,11 +60,6 @@ export default {
     setData: function (tournament) {
       let kind = tournament.current.kind
       let index = tournament.current.index
-      if (kind === 'tryout') {
-        kind = 'tryouts'
-      } else if (kind === 'semi') {
-        kind = 'semis'
-      }
 
       if (kind === 'final') {
         this.$set('match', Match.fromObject(tournament[kind]))

--- a/js/src/components/PostMatch.vue
+++ b/js/src/components/PostMatch.vue
@@ -82,12 +82,6 @@ export default {
       let index = tournament.current.index
       let kind = tournament.current.kind
 
-      if (kind === 'tryout') {
-        kind = 'tryouts'
-      } else if (kind === 'semi') {
-        kind = 'semis'
-      }
-
       if (kind === 'final') {
         match = Match.fromObject(tournament[kind])
       } else {
@@ -96,19 +90,13 @@ export default {
 
       if (!match.isStarted) {
         // If we're on the first match, there is no previous, so bail.
-        if (index === 0 && kind === 'tryouts') {
+        if (index === 0 && kind === 'tryout') {
           this.$set('tournament', Tournament.fromObject(tournament))
           return
         }
 
         index = tournament.previous.index
         kind = tournament.previous.kind
-
-        if (kind === 'tryout') {
-          kind = 'tryouts'
-        } else if (kind === 'semi') {
-          kind = 'semis'
-        }
 
         if (kind === 'final') {
           match = Match.fromObject(tournament[kind])

--- a/js/src/components/ScoreScreen.vue
+++ b/js/src/components/ScoreScreen.vue
@@ -32,11 +32,6 @@ export default {
       let kind = tournament.current.kind
       let index = tournament.current.index
       let match
-      if (kind === 'tryout') {
-        kind = 'tryouts'
-      } else if (kind === 'semi') {
-        kind = 'semis'
-      }
 
       if (kind === 'final') {
         match = Match.fromObject(tournament[kind])

--- a/js/src/components/TournamentOverview.vue
+++ b/js/src/components/TournamentOverview.vue
@@ -45,7 +45,7 @@
     <div class="category tryouts">
       <h3>Tryouts</h3>
       <div class="matches">
-        <template v-for="m in tournament.tryouts">
+        <template v-for="m in tournament.tryout">
           <match-overview :match="m" class="match {{m.kind}}">
         </template>
       </div>
@@ -55,7 +55,7 @@
     <div class="category semis">
       <h3>Semi-finals</h3>
       <div class="matches">
-        <template v-for="m in tournament.semis">
+        <template v-for="m in tournament.semi">
           <match-overview :match="m" class="match {{m.kind}}">
         </template>
       </div>
@@ -127,12 +127,6 @@ export default {
     nextMatch: function () {
       let kind = this.tournament.current.kind
       let idx = this.tournament.current.index
-
-      if (kind === 'tryout') {
-        kind = 'tryouts'
-      } else if (kind === 'semi') {
-        kind = 'semis'
-      }
 
       console.log("kind", kind)
       let m

--- a/js/src/models/Tournament.js
+++ b/js/src/models/Tournament.js
@@ -44,7 +44,7 @@ export default class Tournament {
 
   get canShuffle () {
     // We can only shuffle before the first match has been started.
-    let match = Match.fromObject(this.tryouts[0])
+    let match = Match.fromObject(this.tryout[0])
     return !match.isStarted
   }
 

--- a/tournament.go
+++ b/tournament.go
@@ -19,8 +19,8 @@ type Tournament struct {
 	Winners     []Player     `json:"winners"` // TODO(thiderman): Refactor to pointer
 	Runnerups   []*Person    `json:"runnerups"`
 	Judges      []Judge      `json:"judges"`
-	Tryouts     []*Match     `json:"tryouts"`
-	Semis       []*Match     `json:"semis"`
+	Tryouts     []*Match     `json:"tryout"`
+	Semis       []*Match     `json:"semi"`
 	Final       *Match       `json:"final"`
 	Current     CurrentMatch `json:"current"`
 	Previous    CurrentMatch `json:"previous"`


### PR DESCRIPTION
Removes the kind pluralization logic from the frontend. It's annoying and duplicated everywhere.

This also helps expose the surface area for the jettisoning of the `tryout`, `semi`, and `final` objects on the main tournament object.