### PR TITLE
Display the title of the next level

### DIFF
--- a/js/src/components/NextScreen.vue
+++ b/js/src/components/NextScreen.vue
@@ -14,18 +14,21 @@
     </div>
   </div>
 
-  <h1>{{match.title}}</h1>
+  <div class="info">
+    <h1 class="match-title">{{match.title}}</h1>
+    <h2 class="level-title">{{match.levelTitle}}</h2>
 
-  <div class="timer">
-    {{countdown.time}}
-  </div>
-
-    <div class="players">
-      <template v-for="(player, index) in playersReversed" ref="players">
-        <preview-player :index="index + 1" :player="player" :match="match"></preview-player>
-      </template>
+    <div class="timer">
+      {{countdown.time}}
     </div>
   </div>
+
+  <div class="players">
+    <template v-for="(player, index) in playersReversed" ref="players">
+      <preview-player :index="index + 1" :player="player" :match="match"></preview-player>
+    </template>
+  </div>
+</div>
 </template>
 
 <script>
@@ -133,28 +136,38 @@ export default {
   }
 }
 
-.players {
-  width: 100%;
+.info {
+  display: flex;
+  flex-direction: column;
 
-  .player {
-    width: 25%;
-    display: block;
-    float: left;
+  .match-title {
+    font-size: 5em;
+    margin-bottom: 25px;
+  }
+
+  .level-title {
+    margin-bottom: 75px;
+  }
+
+  .match-title, .level-title {
+    margin-top: 0;
   }
 }
 
-h1 {
-  /* margin-top: -50px; */
-  font-size: 5em;
-  margin-bottom: -1em;
+.players {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+
+  .player {
+    width: 25%;
+    display: inline-block;
+  }
 }
 
 .timer {
-  margin: 0.5em auto 0.25em;
-  width: 3em;
   font-size: 12em;
   text-align: center;
-  padding: 0.08em 0.4em;
 }
 
 </style>


### PR DESCRIPTION
<img width="595" alt="screen shot 2018-03-29 at 22 06 42" src="https://user-images.githubusercontent.com/1063646/38110948-933de566-339d-11e8-9868-bbd7b177d536.png">

Also waves the flexbox magic wand to remove the weird
margin and padding based layout.

Resolves #155 