### PR TITLE
Set the inital clock time to be the current time.

### DIFF
--- a/js/src/models/Timer.js
+++ b/js/src/models/Timer.js
@@ -56,11 +56,16 @@ export class Countdown {
 
 export class Clock {
   constructor () {
-    this.time = "00:00 (+02:00)"
+    this.time = this._getTime()
   }
+
   start () {
     setInterval(() => {
-      this.time = moment().format("HH:mm (Z)")
+      this.time = this._getTime()
     }, 1000)
+  }
+
+  _getTime () {
+    return moment().format("HH:mm (Z)")
   }
 }


### PR DESCRIPTION
Before, if there was an error, the time would default to 00:00, which
isn't usually the correct time.

Resolves #154.